### PR TITLE
Update chalk to version 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "action-selector": "^1.0.2",
     "bulbo": "^7.0.1",
     "callsites": "^3.1.0",
-    "chalk": "^3.0.0",
+    "chalk": "^4.0.0",
     "find-root": "^1.1.0",
     "minimisted": "^2.0.1",
     "pad-right": "^0.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,6 +487,14 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"


### PR DESCRIPTION
This pull request was created using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
It bumps chalk to version 4.0.0.

<strong>Sign up your project [here](https://jsfix.live/scanner) to receive notifications about other packages updates JSFIX can help with.</strong>

***<h3> Pull request details</h3>

<details open><summary><strong> 🚧 - Manual review items (please check before merge)</strong></summary><blockquote class="pr-blockquote"><details>
<summary>Breaking changes not automatically fixable by JSFIX.</summary><blockquote class="pr-blockquote">

<details open>
<summary>General breaking changes (not related to specific API usages in your code).</summary>

* Require Node.js 10
</details>

</blockquote></details>

</blockquote></details><details><summary>Additional details</summary><blockquote class="pr-blockquote"><details>
<summary>Breaking changes where JSFIX found that there were no occurrences.</summary>

* Change the Level TypeScript type to be a union instead of enum
</details>

</blockquote></details>

***

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.